### PR TITLE
feat: hide completed tasks

### DIFF
--- a/.github/workflows/xctest.yml
+++ b/.github/workflows/xctest.yml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Run Tests (iPhone 16, iOS 18)
+    - name: Run Tests (iPhone 15, iOS 18)
       run: |
         xcodebuild test \
           -scheme 'Relist Beta (iOS)' \
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0'
+          -destination 'platform=iOS Simulator,name=iPhone 15,OS=18.0'

--- a/.github/workflows/xctest.yml
+++ b/.github/workflows/xctest.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   test-ios:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v4
-    - name: Run Tests (iPhone 15, iOS 18)
+    - name: Run Tests (iPhone 16, iOS 18)
       run: |
         xcodebuild test \
           -scheme 'Relist Beta (iOS)' \
-          -destination 'platform=iOS Simulator,name=iPhone 15,OS=18.0'
+          -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0'

--- a/.github/workflows/xctest.yml
+++ b/.github/workflows/xctest.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run Tests (iPhone 16, iOS 18)
-      run: xcodebuild test \
-        -scheme 'Relist Beta (iOS)' \
-        -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0'
+      run: |
+        xcodebuild test \
+          -scheme 'Relist Beta (iOS)' \
+          -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0'

--- a/.github/workflows/xctest.yml
+++ b/.github/workflows/xctest.yml
@@ -10,10 +10,16 @@ jobs:
   test-ios:
     runs-on: macos-15
 
+    env:
+      IPHONE: "16"
+      IOS: "18.0"
+
     steps:
     - uses: actions/checkout@v4
-    - name: Run Tests (iPhone 16, iOS 18)
+    - name: Run Tests (iPhone ${{ env.IPHONE }}, iOS ${{ env.IOS }})
       run: |
         xcodebuild test \
           -scheme 'Relist Beta (iOS)' \
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0'
+          -destination 'platform=iOS Simulator,\
+            name=iPhone ${{ env.IPHONE }},\
+            OS=${{ env.IOS }}'

--- a/.github/workflows/xctest.yml
+++ b/.github/workflows/xctest.yml
@@ -1,0 +1,18 @@
+name: XCTest
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test-ios:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run Tests (iPhone 16, iOS 18)
+      run: xcodebuild test \
+        -scheme 'Relist Beta (iOS)' \
+        -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0'

--- a/.github/workflows/xctest.yml
+++ b/.github/workflows/xctest.yml
@@ -20,6 +20,4 @@ jobs:
       run: |
         xcodebuild test \
           -scheme 'Relist Beta (iOS)' \
-          -destination 'platform=iOS Simulator,\
-            name=iPhone ${{ env.IPHONE }},\
-            OS=${{ env.IOS }}'
+          -destination "platform=iOS Simulator,name=iPhone ${{ env.IPHONE }},OS=${{ env.IOS }}"

--- a/Relist.xcodeproj/project.pbxproj
+++ b/Relist.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		FF06C33429D70F4B0095AEDE /* AnimatedSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06C33329D70F4B0095AEDE /* AnimatedSeparatorView.swift */; };
+		FF06C33529D70F4B0095AEDE /* AnimatedSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06C33329D70F4B0095AEDE /* AnimatedSeparatorView.swift */; };
+		FF06C33629D70F4B0095AEDE /* AnimatedSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06C33329D70F4B0095AEDE /* AnimatedSeparatorView.swift */; };
+		FF06C33729D70F4B0095AEDE /* AnimatedSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06C33329D70F4B0095AEDE /* AnimatedSeparatorView.swift */; };
 		FF18AC29284A32E8000FA842 /* TaskEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF18AC28284A32E8000FA842 /* TaskEditorView.swift */; };
 		FF18AC2A284A32E8000FA842 /* TaskEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF18AC28284A32E8000FA842 /* TaskEditorView.swift */; };
 		FF1D0D862844331200C710B1 /* ListEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1D0D852844331200C710B1 /* ListEditorView.swift */; };
@@ -21,6 +25,12 @@
 		FF2BEC2028F845CE0022F675 /* TaskItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2BEC1E28F845CE0022F675 /* TaskItemView.swift */; };
 		FF2BEC2128F845CE0022F675 /* TaskItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2BEC1E28F845CE0022F675 /* TaskItemView.swift */; };
 		FF2BEC2228F845CE0022F675 /* TaskItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2BEC1E28F845CE0022F675 /* TaskItemView.swift */; };
+		FF2C68212CF2B48A00B15E0B /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2C68202CF2B47D00B15E0B /* Bundle.swift */; };
+		FF2C68222CF2B48A00B15E0B /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2C68202CF2B47D00B15E0B /* Bundle.swift */; };
+		FF2C68232CF2B48A00B15E0B /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2C68202CF2B47D00B15E0B /* Bundle.swift */; };
+		FF2C68242CF2B48A00B15E0B /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2C68202CF2B47D00B15E0B /* Bundle.swift */; };
+		FF2C68252CF2B48A00B15E0B /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2C68202CF2B47D00B15E0B /* Bundle.swift */; };
+		FF2C68262CF2B48A00B15E0B /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2C68202CF2B47D00B15E0B /* Bundle.swift */; };
 		FF317E3C286C7E3300DC2335 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF317E3B286C7E3300DC2335 /* CircularProgressView.swift */; };
 		FF317E3D286C7E3300DC2335 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF317E3B286C7E3300DC2335 /* CircularProgressView.swift */; };
 		FF317E3E286C7E3300DC2335 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF317E3B286C7E3300DC2335 /* CircularProgressView.swift */; };
@@ -37,6 +47,38 @@
 		FF8B8EF6285E240A0033C4BD /* ListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8B8EF4285E240A0033C4BD /* ListItemView.swift */; };
 		FF8B8EF7285E240A0033C4BD /* ListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8B8EF4285E240A0033C4BD /* ListItemView.swift */; };
 		FF8B8EF8285E240A0033C4BD /* ListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8B8EF4285E240A0033C4BD /* ListItemView.swift */; };
+		FF90CD5C29296F4D001579DC /* Animation+instant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF90CD5B29296F4D001579DC /* Animation+instant.swift */; };
+		FF90CD5D29296F4D001579DC /* Animation+instant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF90CD5B29296F4D001579DC /* Animation+instant.swift */; };
+		FF90CD5E29296F4D001579DC /* Animation+instant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF90CD5B29296F4D001579DC /* Animation+instant.swift */; };
+		FF90CD5F29296F4D001579DC /* Animation+instant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF90CD5B29296F4D001579DC /* Animation+instant.swift */; };
+		FF90CD6029296F4D001579DC /* Animation+instant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF90CD5B29296F4D001579DC /* Animation+instant.swift */; };
+		FF90CD6129296F4D001579DC /* Animation+instant.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF90CD5B29296F4D001579DC /* Animation+instant.swift */; };
+		FF9718FD29ED7C7000A4AF18 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9718FC29ED7C7000A4AF18 /* Color.swift */; };
+		FF9718FE29ED7C7000A4AF18 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9718FC29ED7C7000A4AF18 /* Color.swift */; };
+		FF9718FF29ED7C7000A4AF18 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9718FC29ED7C7000A4AF18 /* Color.swift */; };
+		FF97190029ED7C7000A4AF18 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9718FC29ED7C7000A4AF18 /* Color.swift */; };
+		FF97190129ED7C7000A4AF18 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9718FC29ED7C7000A4AF18 /* Color.swift */; };
+		FF97190229ED7C7000A4AF18 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9718FC29ED7C7000A4AF18 /* Color.swift */; };
+		FFDF37D929F43FB600289812 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A28C2823EE530088DD67 /* Persistence.swift */; };
+		FFDF37DA29F43FB600289812 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A28C2823EE530088DD67 /* Persistence.swift */; };
+		FFDF37E029F4488C00289812 /* RoutineTask+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E23762843CFBD0028EF88 /* RoutineTask+CoreDataClass.swift */; };
+		FFDF37E129F4488C00289812 /* RoutineList+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E23782843CFBD0028EF88 /* RoutineList+CoreDataClass.swift */; };
+		FFDF37E229F4488C00289812 /* RoutineList+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E23792843CFBD0028EF88 /* RoutineList+CoreDataProperties.swift */; };
+		FFDF37E329F4488C00289812 /* RelistApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A28A2823EE530088DD67 /* RelistApp.swift */; };
+		FFDF37E429F4488C00289812 /* ListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A28B2823EE530088DD67 /* ListsView.swift */; };
+		FFDF37E529F4488C00289812 /* ListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8B8EF4285E240A0033C4BD /* ListItemView.swift */; };
+		FFDF37E629F4488C00289812 /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF317E3B286C7E3300DC2335 /* CircularProgressView.swift */; };
+		FFDF37E729F4488C00289812 /* ListEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1D0D852844331200C710B1 /* ListEditorView.swift */; };
+		FFDF37E829F4488C00289812 /* TaskEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF18AC28284A32E8000FA842 /* TaskEditorView.swift */; };
+		FFDF37E929F4488C00289812 /* TasksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF668077282D2FCD00C52CCE /* TasksView.swift */; };
+		FFDF37EA29F4488C00289812 /* TaskItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2BEC1E28F845CE0022F675 /* TaskItemView.swift */; };
+		FFDF37EB29F4488C00289812 /* AnimatedSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06C33329D70F4B0095AEDE /* AnimatedSeparatorView.swift */; };
+		FFDF37EC29F4488C00289812 /* Assets.xcassets in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A28D2823EE550088DD67 /* Assets.xcassets */; };
+		FFDF37ED29F4488C00289812 /* Relist.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A2882823EE530088DD67 /* Relist.xcdatamodeld */; };
+		FFDF37F529F4488C00289812 /* Relist Beta (iOS).app in Sources */ = {isa = PBXBuildFile; fileRef = FFE726F728575C770018B9D7 /* Relist Beta (iOS).app */; };
+		FFDF37F729F4488C00289812 /* CloudKit.framework in Sources */ = {isa = PBXBuildFile; fileRef = FFEE8F022854BAA5009CF365 /* CloudKit.framework */; };
+		FFDF37FA29F4493400289812 /* Relist (iOS).entitlements in Sources */ = {isa = PBXBuildFile; fileRef = FFEE8EFE2854BA17009CF365 /* Relist (iOS).entitlements */; };
+		FFDF37FB29F44CDB00289812 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFEE8F022854BAA5009CF365 /* CloudKit.framework */; };
 		FFE726E528575C770018B9D7 /* TaskEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF18AC28284A32E8000FA842 /* TaskEditorView.swift */; };
 		FFE726E628575C770018B9D7 /* RoutineList+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E23782843CFBD0028EF88 /* RoutineList+CoreDataClass.swift */; };
 		FFE726E728575C770018B9D7 /* RelistApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A28A2823EE530088DD67 /* RelistApp.swift */; };
@@ -47,7 +89,6 @@
 		FFE726EC28575C770018B9D7 /* Relist.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A2882823EE530088DD67 /* Relist.xcdatamodeld */; };
 		FFE726ED28575C770018B9D7 /* ListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A28B2823EE530088DD67 /* ListsView.swift */; };
 		FFE726EE28575C770018B9D7 /* ListEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1D0D852844331200C710B1 /* ListEditorView.swift */; };
-		FFE726F028575C770018B9D7 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFEE8F002854BA21009CF365 /* CloudKit.framework */; };
 		FFE726F328575C770018B9D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FFF3A28D2823EE550088DD67 /* Assets.xcassets */; };
 		FFE726FB28575E260018B9D7 /* TaskEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF18AC28284A32E8000FA842 /* TaskEditorView.swift */; };
 		FFE726FC28575E260018B9D7 /* RoutineList+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E23782843CFBD0028EF88 /* RoutineList+CoreDataClass.swift */; };
@@ -61,7 +102,6 @@
 		FFE7270428575E260018B9D7 /* ListEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1D0D852844331200C710B1 /* ListEditorView.swift */; };
 		FFE7270628575E260018B9D7 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFEE8F022854BAA5009CF365 /* CloudKit.framework */; };
 		FFE7270928575E260018B9D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FFF3A28D2823EE550088DD67 /* Assets.xcassets */; };
-		FFEE8F012854BA21009CF365 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFEE8F002854BA21009CF365 /* CloudKit.framework */; };
 		FFEE8F032854BAA5009CF365 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFEE8F022854BAA5009CF365 /* CloudKit.framework */; };
 		FFF3A2A42823EE550088DD67 /* Tests_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A2A32823EE550088DD67 /* Tests_iOS.swift */; };
 		FFF3A2A62823EE550088DD67 /* Tests_iOSLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF3A2A52823EE550088DD67 /* Tests_iOSLaunchTests.swift */; };
@@ -80,6 +120,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		FFDF37DB29F4473200289812 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FFF3A2832823EE520088DD67 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FFE726E328575C770018B9D7;
+			remoteInfo = "Relist Beta (iOS)";
+		};
 		FFF3A2A02823EE550088DD67 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FFF3A2832823EE520088DD67 /* Project object */;
@@ -97,21 +144,24 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		FF06C33329D70F4B0095AEDE /* AnimatedSeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedSeparatorView.swift; sourceTree = "<group>"; };
 		FF18AC28284A32E8000FA842 /* TaskEditorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskEditorView.swift; sourceTree = "<group>"; };
 		FF1D0D852844331200C710B1 /* ListEditorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListEditorView.swift; sourceTree = "<group>"; };
 		FF2BEC1728F83EC90022F675 /* IDETemplateMacros.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = IDETemplateMacros.plist; path = Relist.xcodeproj/xcshareddata/IDETemplateMacros.plist; sourceTree = "<group>"; };
 		FF2BEC1E28F845CE0022F675 /* TaskItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskItemView.swift; sourceTree = "<group>"; };
+		FF2C68202CF2B47D00B15E0B /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		FF317E3B286C7E3300DC2335 /* CircularProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
-		FF4E23762843CFBD0028EF88 /* RoutineTask+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoutineTask+CoreDataClass.swift"; sourceTree = "<group>"; };
+		FF4E23762843CFBD0028EF88 /* RoutineTask+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoutineTask+CoreDataClass.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.xcfilelist; };
 		FF4E23782843CFBD0028EF88 /* RoutineList+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoutineList+CoreDataClass.swift"; sourceTree = "<group>"; };
 		FF4E23792843CFBD0028EF88 /* RoutineList+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RoutineList+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		FF668077282D2FCD00C52CCE /* TasksView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TasksView.swift; sourceTree = "<group>"; };
 		FF8B8EF4285E240A0033C4BD /* ListItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListItemView.swift; sourceTree = "<group>"; };
+		FF90CD5B29296F4D001579DC /* Animation+instant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Animation+instant.swift"; sourceTree = "<group>"; };
+		FF9718FC29ED7C7000A4AF18 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FFE726F728575C770018B9D7 /* Relist Beta (iOS).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Relist Beta (iOS).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFE726F828575C770018B9D7 /* Relist Beta (iOS)-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Relist Beta (iOS)-Info.plist"; path = "/Users/codycody/uturnr/relist/Relist Beta (iOS)-Info.plist"; sourceTree = "<absolute>"; };
 		FFE7270D28575E260018B9D7 /* Relist Beta (macOS).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Relist Beta (macOS).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFEE8EFE2854BA17009CF365 /* Relist (iOS).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Relist (iOS).entitlements"; sourceTree = "<group>"; };
-		FFEE8F002854BA21009CF365 /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.5.sdk/System/Library/Frameworks/CloudKit.framework; sourceTree = DEVELOPER_DIR; };
 		FFEE8F022854BAA5009CF365 /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		FFEE8F042854BACE009CF365 /* Relist--iOS--Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Relist--iOS--Info.plist"; sourceTree = "<group>"; };
 		FFF3A2892823EE530088DD67 /* Shared.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Shared.xcdatamodel; sourceTree = "<group>"; };
@@ -135,7 +185,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FFE726F028575C770018B9D7 /* CloudKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,7 +200,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FFEE8F012854BA21009CF365 /* CloudKit.framework in Frameworks */,
+				FFDF37FB29F44CDB00289812 /* CloudKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -190,11 +239,27 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		FF90CD6229296F54001579DC /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				FF2C68202CF2B47D00B15E0B /* Bundle.swift */,
+				FF90CD5B29296F4D001579DC /* Animation+instant.swift */,
+				FF9718FC29ED7C7000A4AF18 /* Color.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		FF90CD6A292970B3001579DC /* Animations */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Animations;
+			sourceTree = "<group>";
+		};
 		FFEE8EFF2854BA21009CF365 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				FFEE8F022854BAA5009CF365 /* CloudKit.framework */,
-				FFEE8F002854BA21009CF365 /* CloudKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -218,6 +283,8 @@
 		FFF3A2872823EE520088DD67 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				FF90CD6A292970B3001579DC /* Animations */,
+				FF90CD6229296F54001579DC /* Extensions */,
 				FF4E23752843CD090028EF88 /* Model */,
 				FFF3A28A2823EE530088DD67 /* RelistApp.swift */,
 				FFF3A28B2823EE530088DD67 /* ListsView.swift */,
@@ -227,6 +294,7 @@
 				FF18AC28284A32E8000FA842 /* TaskEditorView.swift */,
 				FF668077282D2FCD00C52CCE /* TasksView.swift */,
 				FF2BEC1E28F845CE0022F675 /* TaskItemView.swift */,
+				FF06C33329D70F4B0095AEDE /* AnimatedSeparatorView.swift */,
 				FFF3A28C2823EE530088DD67 /* Persistence.swift */,
 				FFF3A28D2823EE550088DD67 /* Assets.xcassets */,
 				FFF3A2882823EE530088DD67 /* Relist.xcdatamodeld */,
@@ -356,6 +424,7 @@
 			);
 			dependencies = (
 				FFF3A2A12823EE550088DD67 /* PBXTargetDependency */,
+				FFDF37DC29F4473200289812 /* PBXTargetDependency */,
 			);
 			name = "Tests iOS";
 			productName = "Tests iOS";
@@ -388,7 +457,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1330;
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1610;
 				TargetAttributes = {
 					FFF3A2912823EE550088DD67 = {
 						CreatedOnToolsVersion = 13.3.1;
@@ -398,7 +467,7 @@
 					};
 					FFF3A29E2823EE550088DD67 = {
 						CreatedOnToolsVersion = 13.3.1;
-						TestTargetID = FFF3A2912823EE550088DD67;
+						TestTargetID = FFE726E328575C770018B9D7;
 					};
 					FFF3A2AA2823EE550088DD67 = {
 						CreatedOnToolsVersion = 13.3.1;
@@ -497,11 +566,15 @@
 				FFE726E828575C770018B9D7 /* RoutineList+CoreDataProperties.swift in Sources */,
 				FFE726E928575C770018B9D7 /* RoutineTask+CoreDataClass.swift in Sources */,
 				FFE726EA28575C770018B9D7 /* Persistence.swift in Sources */,
+				FF06C33629D70F4B0095AEDE /* AnimatedSeparatorView.swift in Sources */,
 				FFE726EB28575C770018B9D7 /* TasksView.swift in Sources */,
 				FFE726EC28575C770018B9D7 /* Relist.xcdatamodeld in Sources */,
+				FF90CD6029296F4D001579DC /* Animation+instant.swift in Sources */,
 				FFE726ED28575C770018B9D7 /* ListsView.swift in Sources */,
+				FF2C68212CF2B48A00B15E0B /* Bundle.swift in Sources */,
 				FF317E3E286C7E3300DC2335 /* CircularProgressView.swift in Sources */,
 				FFE726EE28575C770018B9D7 /* ListEditorView.swift in Sources */,
+				FF97190129ED7C7000A4AF18 /* Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -517,11 +590,15 @@
 				FFE726FE28575E260018B9D7 /* RoutineList+CoreDataProperties.swift in Sources */,
 				FFE726FF28575E260018B9D7 /* RoutineTask+CoreDataClass.swift in Sources */,
 				FFE7270028575E260018B9D7 /* Persistence.swift in Sources */,
+				FF06C33729D70F4B0095AEDE /* AnimatedSeparatorView.swift in Sources */,
 				FFE7270128575E260018B9D7 /* TasksView.swift in Sources */,
 				FFE7270228575E260018B9D7 /* Relist.xcdatamodeld in Sources */,
+				FF90CD6129296F4D001579DC /* Animation+instant.swift in Sources */,
 				FFE7270328575E260018B9D7 /* ListsView.swift in Sources */,
+				FF2C68262CF2B48A00B15E0B /* Bundle.swift in Sources */,
 				FF317E3F286C7E3300DC2335 /* CircularProgressView.swift in Sources */,
 				FFE7270428575E260018B9D7 /* ListEditorView.swift in Sources */,
+				FF97190229ED7C7000A4AF18 /* Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -537,11 +614,15 @@
 				FF4E23802843CFBD0028EF88 /* RoutineList+CoreDataProperties.swift in Sources */,
 				FF4E237A2843CFBD0028EF88 /* RoutineTask+CoreDataClass.swift in Sources */,
 				FFF3A2B92823EE550088DD67 /* Persistence.swift in Sources */,
+				FF06C33429D70F4B0095AEDE /* AnimatedSeparatorView.swift in Sources */,
 				FF668078282D2FCD00C52CCE /* TasksView.swift in Sources */,
 				FFF3A2B32823EE550088DD67 /* Relist.xcdatamodeld in Sources */,
+				FF90CD5C29296F4D001579DC /* Animation+instant.swift in Sources */,
 				FFF3A2B72823EE550088DD67 /* ListsView.swift in Sources */,
+				FF2C68222CF2B48A00B15E0B /* Bundle.swift in Sources */,
 				FF317E3C286C7E3300DC2335 /* CircularProgressView.swift in Sources */,
 				FF1D0D862844331200C710B1 /* ListEditorView.swift in Sources */,
+				FF9718FD29ED7C7000A4AF18 /* Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -557,11 +638,15 @@
 				FF4E23812843CFBD0028EF88 /* RoutineList+CoreDataProperties.swift in Sources */,
 				FF4E237B2843CFBD0028EF88 /* RoutineTask+CoreDataClass.swift in Sources */,
 				FFF3A2BA2823EE550088DD67 /* Persistence.swift in Sources */,
+				FF06C33529D70F4B0095AEDE /* AnimatedSeparatorView.swift in Sources */,
 				FF668079282D2FCD00C52CCE /* TasksView.swift in Sources */,
 				FFF3A2B42823EE550088DD67 /* Relist.xcdatamodeld in Sources */,
+				FF90CD5D29296F4D001579DC /* Animation+instant.swift in Sources */,
 				FFF3A2B82823EE550088DD67 /* ListsView.swift in Sources */,
+				FF2C68252CF2B48A00B15E0B /* Bundle.swift in Sources */,
 				FF317E3D286C7E3300DC2335 /* CircularProgressView.swift in Sources */,
 				FF1D0D872844331200C710B1 /* ListEditorView.swift in Sources */,
+				FF9718FE29ED7C7000A4AF18 /* Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -569,8 +654,29 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FFDF37FA29F4493400289812 /* Relist (iOS).entitlements in Sources */,
+				FFDF37E029F4488C00289812 /* RoutineTask+CoreDataClass.swift in Sources */,
+				FFDF37E129F4488C00289812 /* RoutineList+CoreDataClass.swift in Sources */,
+				FFDF37E229F4488C00289812 /* RoutineList+CoreDataProperties.swift in Sources */,
+				FFDF37E329F4488C00289812 /* RelistApp.swift in Sources */,
+				FFDF37E429F4488C00289812 /* ListsView.swift in Sources */,
+				FFDF37E529F4488C00289812 /* ListItemView.swift in Sources */,
+				FFDF37E629F4488C00289812 /* CircularProgressView.swift in Sources */,
+				FFDF37E729F4488C00289812 /* ListEditorView.swift in Sources */,
+				FFDF37E829F4488C00289812 /* TaskEditorView.swift in Sources */,
+				FFDF37E929F4488C00289812 /* TasksView.swift in Sources */,
+				FFDF37EA29F4488C00289812 /* TaskItemView.swift in Sources */,
+				FF2C68232CF2B48A00B15E0B /* Bundle.swift in Sources */,
+				FFDF37EB29F4488C00289812 /* AnimatedSeparatorView.swift in Sources */,
+				FFDF37EC29F4488C00289812 /* Assets.xcassets in Sources */,
+				FFDF37ED29F4488C00289812 /* Relist.xcdatamodeld in Sources */,
+				FFDF37F529F4488C00289812 /* Relist Beta (iOS).app in Sources */,
+				FFDF37F729F4488C00289812 /* CloudKit.framework in Sources */,
 				FFF3A2A62823EE550088DD67 /* Tests_iOSLaunchTests.swift in Sources */,
+				FFDF37D929F43FB600289812 /* Persistence.swift in Sources */,
 				FFF3A2A42823EE550088DD67 /* Tests_iOS.swift in Sources */,
+				FF90CD5E29296F4D001579DC /* Animation+instant.swift in Sources */,
+				FF9718FF29ED7C7000A4AF18 /* Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -579,13 +685,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				FFF3A2B22823EE550088DD67 /* Tests_macOSLaunchTests.swift in Sources */,
+				FF2C68242CF2B48A00B15E0B /* Bundle.swift in Sources */,
+				FFDF37DA29F43FB600289812 /* Persistence.swift in Sources */,
 				FFF3A2B02823EE550088DD67 /* Tests_macOS.swift in Sources */,
+				FF90CD5F29296F4D001579DC /* Animation+instant.swift in Sources */,
+				FF97190029ED7C7000A4AF18 /* Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		FFDF37DC29F4473200289812 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FFE726E328575C770018B9D7 /* Relist Beta (iOS) */;
+			targetProxy = FFDF37DB29F4473200289812 /* PBXContainerItemProxy */;
+		};
 		FFF3A2A12823EE550088DD67 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FFF3A2912823EE550088DD67 /* Relist (iOS) */;
@@ -680,6 +795,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KLQGJ9XU3B;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -709,6 +825,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KLQGJ9XU3B;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -761,9 +878,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -819,9 +938,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -916,6 +1037,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KLQGJ9XU3B;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -945,6 +1067,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = KLQGJ9XU3B;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -967,7 +1090,6 @@
 		FFF3A2C62823EE550088DD67 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LE39A4G2MZ;
@@ -980,14 +1102,13 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "Relist (iOS)";
+				TEST_TARGET_NAME = "Relist Beta (iOS)";
 			};
 			name = Debug;
 		};
 		FFF3A2C72823EE550088DD67 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LE39A4G2MZ;
@@ -1000,7 +1121,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "Relist (iOS)";
+				TEST_TARGET_NAME = "Relist Beta (iOS)";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1008,9 +1129,9 @@
 		FFF3A2C92823EE550088DD67 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = LE39A4G2MZ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
@@ -1027,9 +1148,9 @@
 		FFF3A2CA2823EE550088DD67 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = LE39A4G2MZ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 12.3;

--- a/Relist.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Relist.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<true/>
+</dict>
+</plist>

--- a/Relist.xcodeproj/xcshareddata/xcbaselines/FFF3A29E2823EE550088DD67.xcbaseline/02976271-FF5B-42CD-A2F7-56C744BFCA0D.plist
+++ b/Relist.xcodeproj/xcshareddata/xcbaselines/FFF3A29E2823EE550088DD67.xcbaseline/02976271-FF5B-42CD-A2F7-56C744BFCA0D.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>Tests_iOS</key>
+		<dict>
+			<key>testLaunchPerformance()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_ApplicationLaunch-AppLaunch.duration</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.542916</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Relist.xcodeproj/xcshareddata/xcbaselines/FFF3A29E2823EE550088DD67.xcbaseline/Info.plist
+++ b/Relist.xcodeproj/xcshareddata/xcbaselines/FFF3A29E2823EE550088DD67.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>02976271-FF5B-42CD-A2F7-56C744BFCA0D</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1 Max</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>modelCode</key>
+				<string>Mac13,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone17,3</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Relist.xcodeproj/xcshareddata/xcschemes/Relist (iOS).xcscheme
+++ b/Relist.xcodeproj/xcshareddata/xcschemes/Relist (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Relist.xcodeproj/xcshareddata/xcschemes/Relist Beta (iOS).xcscheme
+++ b/Relist.xcodeproj/xcshareddata/xcschemes/Relist Beta (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1340"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FFF3A29E2823EE550088DD67"
+               BuildableName = "Tests iOS.xctest"
+               BlueprintName = "Tests iOS"
+               ReferencedContainer = "container:Relist.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -52,7 +62,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"

--- a/Shared/AnimatedSeparatorView.swift
+++ b/Shared/AnimatedSeparatorView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+enum AnimatedSeparatorViewStyle {
+  case navBar
+  case taskItem
+}
+
+private func getColor(_ style: AnimatedSeparatorViewStyle) -> Color {
+  switch style {
+  case .navBar:
+    return .systemBackground.blend(.blue, intensity: 0.8)
+  case .taskItem:
+    return .primary.opacity(0.4)
+  }
+}
+
+/// Use conditional logic to start animation, Use .id() modifier to restart
+/// animation. Animation is played during delay before removal of items from
+/// list when the app is configured to hide completed tasks.
+struct AnimatedSeparatorView: View {
+  var style: AnimatedSeparatorViewStyle
+  /// Animation restarts if this value changes
+  var key: TimeInterval
+  var show = true
+  /// The parent should use the key to determine if this is the latest
+  /// animation and therefore whether to take action upon animation end.
+  var closureWithKey: ((_ key: TimeInterval) -> Void)?
+  let duration = 1.0
+
+  @State private var widthRatio: CGFloat = 0.0
+  
+  var body: some View {
+    GeometryReader { metrics in
+      VStack(spacing: 0) {
+        ZStack {
+          Rectangle()
+            .fill(Color.systemGray5)
+            .frame(width: metrics.size.width, height: 1)
+          if (show) {
+            Rectangle()
+              .fill(getColor(style))
+              .frame(width: metrics.size.width * widthRatio, height: 1)
+              .animation(
+                Animation.linear(duration: duration), value: widthRatio
+              )
+              .onAppear {
+                widthRatio = 0.0
+                widthRatio = 1.0
+                
+                guard let closureTest = closureWithKey else { return }
+                DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                  closureTest(key)
+                }
+              }
+              .frame(
+                maxWidth: .infinity,
+                alignment: .bottomTrailing
+              )
+          }
+        }
+      }.frame(
+        maxWidth: .infinity,
+        alignment: .bottomTrailing
+      )
+    }.frame(height: 1)
+  }
+}

--- a/Shared/Extensions/Animation+instant.swift
+++ b/Shared/Extensions/Animation+instant.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+public extension Animation {
+  static let instant = Animation.linear(duration: 0.0001)
+}

--- a/Shared/Extensions/Bundle.swift
+++ b/Shared/Extensions/Bundle.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+extension Bundle {
+  static var current: Bundle {
+    class __ { }
+    return Bundle(for: __.self)
+  }
+}

--- a/Shared/Extensions/Color.swift
+++ b/Shared/Extensions/Color.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+extension Color {
+  var components: (red: CGFloat, green: CGFloat, blue: CGFloat, opacity: CGFloat) {
+
+    #if canImport(UIKit)
+    typealias NativeColor = UIColor
+    #elseif canImport(AppKit)
+    typealias NativeColor = NSColor
+    #endif
+
+    var r: CGFloat = 0
+    var g: CGFloat = 0
+    var b: CGFloat = 0
+    var o: CGFloat = 0
+
+    guard NativeColor(self).getRed(&r, green: &g, blue: &b, alpha: &o) else {
+      // TODO: handle failure
+      return (0, 0, 0, 0)
+    }
+
+    return (r, g, b, o)
+  }
+}
+
+// https://stackoverflow.com/a/64414674
+extension Color {
+  // MARK: - Text Colors
+  static let lightText = Color(UIColor.lightText)
+  static let darkText = Color(UIColor.darkText)
+  static let placeholderText = Color(UIColor.placeholderText)
+
+  // MARK: - Label Colors
+  static let label = Color(UIColor.label)
+  static let secondaryLabel = Color(UIColor.secondaryLabel)
+  static let tertiaryLabel = Color(UIColor.tertiaryLabel)
+  static let quaternaryLabel = Color(UIColor.quaternaryLabel)
+
+  // MARK: - Background Colors
+  static let systemBackground = Color(UIColor.systemBackground)
+  static let secondarySystemBackground = Color(UIColor.secondarySystemBackground)
+  static let tertiarySystemBackground = Color(UIColor.tertiarySystemBackground)
+  
+  // MARK: - Fill Colors
+  static let systemFill = Color(UIColor.systemFill)
+  static let secondarySystemFill = Color(UIColor.secondarySystemFill)
+  static let tertiarySystemFill = Color(UIColor.tertiarySystemFill)
+  static let quaternarySystemFill = Color(UIColor.quaternarySystemFill)
+  
+  // MARK: - Grouped Background Colors
+  static let systemGroupedBackground = Color(UIColor.systemGroupedBackground)
+  static let secondarySystemGroupedBackground = Color(UIColor.secondarySystemGroupedBackground)
+  static let tertiarySystemGroupedBackground = Color(UIColor.tertiarySystemGroupedBackground)
+  
+  // MARK: - Gray Colors
+  static let systemGray = Color(UIColor.systemGray)
+  static let systemGray2 = Color(UIColor.systemGray2)
+  static let systemGray3 = Color(UIColor.systemGray3)
+  static let systemGray4 = Color(UIColor.systemGray4)
+  static let systemGray5 = Color(UIColor.systemGray5)
+  static let systemGray6 = Color(UIColor.systemGray6)
+  
+  // MARK: - Other Colors
+  static let separator = Color(UIColor.separator)
+  static let opaqueSeparator = Color(UIColor.opaqueSeparator)
+  static let link = Color(UIColor.link)
+}
+
+extension Color {
+  func blend(_ color2: Color, intensity intensity2: CGFloat = 0.5) -> Color {
+    let intensity1 = 1.0 - intensity2
+    
+    let color1 = self
+    
+    guard intensity1 > 0 else { return color2 }
+    guard intensity2 > 0 else { return color1 }
+    
+    let color1Components = color1.components
+    let color2Components = color2.components
+    
+    let (r1, g1, b1, a1): (CGFloat, CGFloat, CGFloat, CGFloat) = (
+      color1Components.red,
+      color1Components.green,
+      color1Components.blue,
+      color1Components.opacity
+    )
+    let (r2, g2, b2, a2): (CGFloat, CGFloat, CGFloat, CGFloat) = (
+      color2Components.red,
+      color2Components.green,
+      color2Components.blue,
+      color2Components.opacity
+    )
+
+    return Color(
+      red: (intensity1 * r1) + (intensity2 * r2),
+      green: (intensity1 * g1) + (intensity2 * g2),
+      blue: (intensity1 * b1) + (intensity2 * b2),
+      opacity: (intensity1 * a1) + (intensity2 * a2)
+    )
+  }
+}

--- a/Shared/Model/RoutineTask+CoreDataClass.swift
+++ b/Shared/Model/RoutineTask+CoreDataClass.swift
@@ -34,7 +34,7 @@ public class RoutineTask: NSManagedObject, Identifiable {
     let entity = NSEntityDescription.entity(forEntityName: "RoutineTask", in: context)!
     super.init(entity: entity, insertInto: context)
     self.id = id
-    self.checked = false
+    self.checked = checked
     self.createdDate = createdDate
     self.name = name
     self.orderIndex = orderIndex

--- a/Shared/Persistence.swift
+++ b/Shared/Persistence.swift
@@ -1,23 +1,54 @@
 import CoreData
+import SwiftUI
 
 struct PersistenceController {
   static let shared = PersistenceController()
   
-  static var preview: PersistenceController = {
-    let result = PersistenceController(inMemory: true)
-    let viewContext = result.container.viewContext
-    
+  static func setupMockList(_ viewContext: NSManagedObjectContext) {
     let list = RoutineList(
       context: viewContext,
-      name: "Test List",
+      name: "Test List 1",
       orderIndex: 0
     )
     
     let _ = RoutineTask(
       context: viewContext,
+      checked: false,
       list: list,
-      name: "Test Task",
+      name: "Test Task 1",
       orderIndex: 0
+    )
+    
+    let _ = RoutineTask(
+      context: viewContext,
+      checked: false,
+      list: list,
+      name: "Test Task 2",
+      orderIndex: 1
+    )
+    
+    let _ = RoutineTask(
+      context: viewContext,
+      checked: false,
+      list: list,
+      name: "Test Task 3",
+      orderIndex: 2
+    )
+    
+    let _ = RoutineTask(
+      context: viewContext,
+      checked: false,
+      list: list,
+      name: "Test Task 4",
+      orderIndex: 3
+    )
+    
+    let _ = RoutineTask(
+      context: viewContext,
+      checked: false,
+      list: list,
+      name: "Test Task 5",
+      orderIndex: 4
     )
     
     do {
@@ -28,6 +59,21 @@ struct PersistenceController {
       let nsError = error as NSError
       fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
     }
+  }
+  
+  static func getPreviewList(_ viewContext: NSManagedObjectContext) -> RoutineList {
+    let request: NSFetchRequest<RoutineList> = RoutineList.fetchRequest()
+
+    let lists = try! viewContext.fetch(request)
+    return lists[0]
+  }
+  
+  static var preview: PersistenceController = {
+    let result = PersistenceController(inMemory: true)
+    let viewContext = result.container.viewContext
+    
+    setupMockList(viewContext)
+
     return result
   }()
   

--- a/Shared/RelistApp.swift
+++ b/Shared/RelistApp.swift
@@ -2,7 +2,24 @@ import SwiftUI
 
 @main
 struct RelistApp: App {
-  let persistenceController = PersistenceController.shared
+  let persistenceController: PersistenceController
+  
+  init() {
+    // Handle UI test automation settings
+    if UserDefaults.standard.bool(forKey: "DISABLE_ANIMATIONS") {
+      UIView.setAnimationsEnabled(false)
+      let scenes = UIApplication.shared.connectedScenes
+      let windowScene = scenes.first as? UIWindowScene
+      windowScene?.windows.first?.layer.speed = 100
+    }
+
+    // Initialize persistenceController based on settings
+    persistenceController = UserDefaults.standard.bool(
+      forKey: "USE_PREVIEW_DATA"
+    ) 
+      ? .preview 
+      : .shared
+  }
   
   var body: some Scene {
     WindowGroup {

--- a/Shared/TaskItemView.swift
+++ b/Shared/TaskItemView.swift
@@ -1,37 +1,135 @@
 import SwiftUI
 import CoreData
 
+struct TaskItemButtonStyle: ButtonStyle {
+  func makeBody(configuration: Self.Configuration) -> some View {
+    configuration.label
+      // Darken the button when tapped. This doesn't happen
+      // fast enough to make the button feel like it has been
+      // tapped, so we will add an additional animation.
+      .background(
+        configuration.isPressed ? Color.systemGray3 : Color.systemBackground
+      )
+  }
+}
+
 struct TaskItemView: View {
   @Environment(\.managedObjectContext) private var viewContext
   
   @ObservedObject var task: RoutineTask
   
-  init(task: RoutineTask) {
-    self.task = task
+  // Completion animation vars
+  /// All tasks currently displaying completion animation
+  @Binding var completingTaskIDs: [String]
+  /// Whether this task is currently displaying completion animation
+  private var isCompleting: Bool {
+    get {
+      completingTaskIDs.contains(task.id)
+    }
   }
+  /// Whether this task is completed. This is immediately true, even while
+  /// the task is displaying completion animation.
+  private var isCompleted: Bool {
+    get {
+      task.checked
+    }
+  }
+
+  let tapBgOpacity = 0.8
+  let animateAwayBgOpacity = 0.125
+  /// Used to simulate faster tap (isPressed) and darkened view
+  /// when animating away.
+  @State private var bgOpacity = 1.0
   
+  @Binding var animationStarted: TimeInterval
+  var showCompleted: Bool
+  
+  init(
+    task: RoutineTask,
+    completingTaskIDs: Binding<[String]>,
+    animationStarted: Binding<TimeInterval>,
+    showCompleted: Bool
+  ) {
+    self.task = task
+    self._completingTaskIDs = completingTaskIDs
+    self._animationStarted = animationStarted
+    self.showCompleted = showCompleted
+  }
   
   var body: some View {
     Button(action: {
       toggleTaskChecked(task: task)
     }) {
-      HStack {
-        Text("\(task.checked ? "☑️" : "")")
-        Text("\(task.orderIndex) - \(task.name)")
+      ZStack {
+        // Fill background with light grey for completed tasks and simulate a
+        // tap. TODO: Fix flickering when scrolling through completed tasks
+        if (task.checked) {
+          Color(uiColor: .systemGray4)
+            .opacity(bgOpacity)
+            .ignoresSafeArea()
+            .onAppear {
+              withAnimation(.none) {
+                bgOpacity = tapBgOpacity
+              }
+
+              DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                withAnimation(.linear(duration: 0.2)) {
+                  bgOpacity = animateAwayBgOpacity
+                }
+              }
+            }
+        }
+
+        // Button content
+        HStack {
+          Text("\(task.checked ? "☑️" : "")")
+
+          Text("\(task.orderIndex) - \(task.name)")
+            .accessibilityIdentifier("taskName")
+            .opacity(isCompleted ? 0.5 : 1.0)
+
+          Spacer()
+        }
+        .animation(.linear, value: task.checked)
+        .padding([.leading], 10)
+
+        // Completed task animation
+        VStack {
+          Spacer()
+          
+          AnimatedSeparatorView(
+            style: .taskItem,
+            key: animationStarted,
+            show: isCompleting && !showCompleted
+          )
+          .id(animationStarted)
+        }
       }
+      // Make entire button area clickable
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(TaskItemButtonStyle())
+    .frame(minHeight: 65)
+    .transaction { transaction in
+      transaction.animation = nil
     }
   }
   
   private func toggleTaskChecked(task: RoutineTask) {
-    withAnimation {
+    // https://developer.apple.com/forums/thread/682779
+    DispatchQueue.main.async {
       task.checked = !task.checked
+      if task.checked && !showCompleted {
+        animationStarted = NSDate().timeIntervalSince1970
+        completingTaskIDs.append(task.id)
+      }
+
       task.list.tasksUpdatedDate = Date.now
       
       do {
         try viewContext.save()
       } catch {
-        // Replace this implementation with code to handle the error appropriately.
-        // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+        // TODO: Proper error handling
         let nsError = error as NSError
         fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
       }
@@ -40,24 +138,20 @@ struct TaskItemView: View {
 }
 
 struct TaskItemView_Previews: PreviewProvider {
-  // TODO: use mock data from Persistence.swift
-  static let list = RoutineList(
-    context: PersistenceController.preview.container.viewContext,
-    name: "Test List",
-    orderIndex: 0
-  )
-  
   static var previews: some View {
-    let _ = RoutineTask(
-      context: PersistenceController.preview.container.viewContext,
-      list: list,
-      name: "Test Task",
-      orderIndex: 0
+    let list = PersistenceController.getPreviewList(
+      PersistenceController.preview.container.viewContext
     )
     
-    TasksView(list: list).environment(
-      \.managedObjectContext,
-       PersistenceController.preview.container.viewContext
-    ).previewInterfaceOrientation(.portraitUpsideDown)
+    if #available(iOS 16.0, *) {
+      NavigationStack {
+        TasksView(list: list).environment(
+          \.managedObjectContext,
+          PersistenceController.preview.container.viewContext
+        )
+      }.previewInterfaceOrientation(.portraitUpsideDown)
+    } else {
+      Text("Preview requires iOS 16")
+    }
   }
 }

--- a/Shared/TasksView.swift
+++ b/Shared/TasksView.swift
@@ -5,10 +5,16 @@ struct TasksView: View {
   @Environment(\.managedObjectContext) private var viewContext
   
   @State private var addTaskViewOpen: Bool = false
+  /// The tasks currently displaying the completion animation (if completed
+  /// tasks are currently hidden)
+  @State private var completingTaskIDs: [String] = []
+  
+  @State private var animationStarted = NSDate().timeIntervalSince1970
+  @State private var showCompleted = false
 
   var list: RoutineList
   
-  static func getRoutineTasksFetchRequest(
+  private static func getRoutineTasksFetchRequest(
     list: RoutineList
   ) -> NSFetchRequest<RoutineTask> {
     let request: NSFetchRequest<RoutineTask> = RoutineTask.fetchRequest()
@@ -20,51 +26,115 @@ struct TasksView: View {
     return request
   }
   
-  @FetchRequest private var tasks: FetchedResults<RoutineTask>
+  @FetchRequest private var tasksFetchedResults: FetchedResults<RoutineTask>
   
   init(list: RoutineList) {
     self.list = list
 
-    _tasks = FetchRequest(
+    _tasksFetchedResults = FetchRequest(
       fetchRequest: TasksView.getRoutineTasksFetchRequest(list: list),
       animation: .default
     )
   }
   
-  var body: some View {
-    List {
-      ForEach(tasks) { task in
-        TaskItemView(task: task)
-      }
-      .onDelete(perform: deleteTasks)
-      .onMove(perform: moveTask)
+  private func getFilteredTasks(
+    tasks: [RoutineTask],
+    completingTaskIDs: [String]
+  ) -> [RoutineTask] {
+    let filteredTasks = tasks.filter { task in
+      let isChecked = task.checked
+      let isCompleting = completingTaskIDs.contains(task.id)
+      return showCompleted || !isChecked || isCompleting
     }
-    .listRowBackground(Ellipse()
-      .background(Color.clear)
-      .foregroundColor(.purple)
-      .opacity(0.3))
-    .environment(\.defaultMinListRowHeight, 65)
-    .toolbar {
-      #if os(iOS)
+    return filteredTasks
+  }
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      let showRemovingAnimation = (
+        completingTaskIDs.count > 0
+        && !showCompleted
+      )
+
+      AnimatedSeparatorView(
+        style: .navBar,
+        key: animationStarted,
+        show: showRemovingAnimation
+      ) { key in
+        let isLastAnimation = key == animationStarted
+        if (isLastAnimation) {
+          withAnimation {
+            completingTaskIDs = []
+          }
+        }
+      }
+      .id(animationStarted)
+      List {
+        let filteredTasks = getFilteredTasks(
+          tasks: Array(tasksFetchedResults),
+          completingTaskIDs: completingTaskIDs
+        )
+
+        ForEach(filteredTasks) { task in
+          TaskItemView(
+            task: task,
+            completingTaskIDs: $completingTaskIDs,
+            animationStarted: $animationStarted,
+            showCompleted: showCompleted
+          )
+        }
+        .onDelete { indexSet in
+          let tasksToDelete = indexSet.map { filteredTasks[$0] }
+          deleteTasks(tasks: tasksToDelete)
+        }
+        .onMove { indexSet, destination in
+          let movedTask = filteredTasks[indexSet[indexSet.startIndex]]
+          let destinationTask = filteredTasks[
+            destination > indexSet[indexSet.startIndex]
+            ? destination - 1
+            : destination
+          ]
+          // The user may be viewing a filtered list, but we need to re-order
+          // the tasks in the full list.
+          let actualDestination = tasksFetchedResults
+            .firstIndex(of: destinationTask) ?? destination
+          
+          moveTask(task: movedTask, destination: actualDestination)
+        }
+        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+        .listRowSeparator(.hidden)
+      }
+      .listStyle(PlainListStyle())
+      .toolbar {
+        ToolbarItem(placement: .navigationBarTrailing) {
+          Button(action: toggleShowCompleted) {
+            Label(
+              "Toggle Show Done",
+              systemImage: showCompleted ? "eye" : "eye.slash"
+            )
+          }
+        }
+
         ToolbarItem(placement: .navigationBarTrailing) {
           Button(action: uncheckAllTasks) {
             Label("Uncheck All", systemImage: "arrow.counterclockwise.circle")
           }
         }
-      
+        #if os(iOS)
         ToolbarItem(placement: .navigationBarTrailing) {
           EditButton()
         }
-      #endif
-
-      ToolbarItem() {
-        Button(action: showAddTask) {
-          Label("Add Task", systemImage: "plus")
-        }
-        .keyboardShortcut("n")
-        .sheet(isPresented: $addTaskViewOpen) {
-          TaskEditorView(list: list)
-            .environment(\.managedObjectContext, self.viewContext)
+        #endif
+        
+        ToolbarItem() {
+          Button(action: showAddTask) {
+            Label("Add Task", systemImage: "plus")
+          }
+          .keyboardShortcut("n")
+          .sheet(isPresented: $addTaskViewOpen) {
+            TaskEditorView(list: list)
+              .environment(\.managedObjectContext, self.viewContext)
+          }
         }
       }
     }
@@ -74,14 +144,38 @@ struct TasksView: View {
     addTaskViewOpen = true
   }
   
-  private func reorderAllTasks() {
-    for (index, task) in tasks.enumerated() {
+  /// Updates the stored orderIndex values for all tasks based on a given
+  /// array of tasks. If no array is provided, all tasks are updated based on
+  /// the current list order.
+  private func reorderAllTasks(orderedTasks: [RoutineTask]? = nil) {
+    let tasksToOrder = orderedTasks ?? Array(tasksFetchedResults)
+    
+    for (index, task) in tasksToOrder.enumerated() {
       task.orderIndex = Int64(index)
+    }
+    
+    list.tasksUpdatedDate = Date.now
+    
+    do {
+      try viewContext.save()
+    } catch {
+      // TODO: Proper error handling
+      let nsError = error as NSError
+      fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+    }
+  }
+  
+  private func toggleShowCompleted() {
+    withAnimation {
+      showCompleted = !showCompleted
     }
   }
   
   private func uncheckAllTasks() {
-    for task in tasks {
+    // TODO: Determine a way to uncheck all tasks in a single update to
+    // see if it helps to prevent animation from showing checked state briefly
+    // when unchecked tasks re-appear
+    for task in tasksFetchedResults {
       task.checked = false
     }
     list.tasksUpdatedDate = Date.now
@@ -89,93 +183,39 @@ struct TasksView: View {
     do {
       try viewContext.save()
     } catch {
-      // Replace this implementation with code to handle the error appropriately.
-      // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+      // TODO: Proper error handling
       let nsError = error as NSError
       fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
     }
   }
   
-  private func moveTask(sets: IndexSet, destination: Int) {
-    // TODO: ensure ordering works with hidden/filtered tasks.
-
-    // First, reorder all tasks in case they somehow lost valid ordering.
-    reorderAllTasks()
-
-    enum Direction {
-      case down
-      case up
-      case unmoved
-    }
+  private func moveTask(task: RoutineTask, destination: Int) {
+    // Get array of all tasks
+    let tasks = Array(tasksFetchedResults)
+    guard let sourceIndex = tasks.firstIndex(of: task) else { return }
     
-    let movedTaskIndex = sets.first!
+    // Remove task from source and insert at destination
+    var reorderedTasks = tasks
+    reorderedTasks.remove(at: sourceIndex)
+    reorderedTasks.insert(task, at: destination)
     
-    let direction: Direction
-
-    if (movedTaskIndex == destination) {
-      direction = .unmoved
-    } else if (movedTaskIndex < destination) {
-      direction = .down
-    } else if (movedTaskIndex > destination) {
-      direction = .up
-    } else {
-      fatalError("Impossible move")
-    }
-    
-    if direction == .unmoved {
-      return
-    }
-    
-    let movedTask = tasks[movedTaskIndex]
-    let destinationForMovedTask = direction == .down
-      ? Int64(destination) - 1
-      : Int64(destination)
-    
-    // Move moved task
-    movedTask.orderIndex = destinationForMovedTask
-    
-    /// First index in other tasks to reorder
-    let startIndex = direction == .down
-      ? movedTaskIndex + 1
-      : destination
-    /// Last index in other tasks to reorder
-    let endIndex = direction == .down
-      ? destination - 1
-      : movedTaskIndex - 1
-
-    let adjustment: Int64 = direction == .down ? -1 : 1
-    
-    // Move other tasks
-    for indexInList in startIndex...endIndex {
-      let currentTask = tasks[indexInList]
-      let newOrderIndex = currentTask.orderIndex + adjustment
-      currentTask.orderIndex = newOrderIndex
-    }
-    
-    list.tasksUpdatedDate = Date.now
-    
-    do {
-      try viewContext.save()
-    } catch {
-      // Replace this implementation with code to handle the error appropriately.
-      // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-      let nsError = error as NSError
-      fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-    }
+    // Update CoreData order to match new array order
+    reorderAllTasks(orderedTasks: reorderedTasks)
   }
   
-  private func deleteTasks(offsets: IndexSet) {
+  private func deleteTasks(tasks: [RoutineTask]) {
     withAnimation {
-      offsets.map { tasks[$0] }.forEach(viewContext.delete)
+      tasks.forEach { task in
+        viewContext.delete(task)
+      }
       list.tasksUpdatedDate = Date.now
       
       do {
+        // Saving the deletion prior to reordering ensures accurate reordering
         try viewContext.save()
         reorderAllTasks()
-        try viewContext.save()
       } catch {
-        // Replace this implementation with code to handle the error appropriately.
-        // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+        // TODO: Proper error handling
         let nsError = error as NSError
         fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
       }
@@ -183,25 +223,22 @@ struct TasksView: View {
   }
 }
 
+/// Note: List show/hide, add/remove animations not working in preview.
 struct TasksView_Previews: PreviewProvider {
-  // TODO: use mock data from Persistence.swift
-  static let list = RoutineList(
-    context: PersistenceController.preview.container.viewContext,
-    name: "Test List",
-    orderIndex: 0
-  )
-  
   static var previews: some View {
-    let _ = RoutineTask(
-      context: PersistenceController.preview.container.viewContext,
-      list: list,
-      name: "Test Task",
-      orderIndex: 0
+    let list = PersistenceController.getPreviewList(
+      PersistenceController.preview.container.viewContext
     )
 
-  TasksView(list: list).environment(
-    \.managedObjectContext,
-     PersistenceController.preview.container.viewContext
-  ).previewInterfaceOrientation(.portraitUpsideDown)
+    if #available(iOS 16.0, *) {
+      NavigationStack {
+        TasksView(list: list).environment(
+          \.managedObjectContext,
+          PersistenceController.preview.container.viewContext
+        )
+      }.previewInterfaceOrientation(.portraitUpsideDown)
+    } else {
+      Text("Preview requires iOS 16")
+    }
   }
 }

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -138,6 +138,9 @@ class Tests_iOS: XCTestCase {
       thenHoldForDuration: 0.5
     )
     
+    // Add a small wait to ensure reordering animation completes
+    Thread.sleep(forTimeInterval: 0.5)
+    
     let movedTask = expectedVisibleTasks.removeFirst()
     expectedVisibleTasks.append(movedTask) // 4, 5, 3
     assertVisibleTasksMatch(expectedVisibleTasks)

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -1,34 +1,157 @@
 import XCTest
 
 class Tests_iOS: XCTestCase {
+  let app = XCUIApplication()
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+    
+    app.launchArguments = [
+      "-DISABLE_ANIMATIONS", "YES",
+      "-USE_PREVIEW_DATA", "YES",
+    ]
+    app.launch()
+  }
 
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+  /// Compares expected array of strings to visible cell contents. As indices
+  /// shows in debug mode, and our test data includes longer names, the strings
+  /// in the second array must only contain the string in the first. (Note:
+  /// debug mode doesn't exist yet so we are always in debug mode)
+  /// ["Task 1", "Task 2"], ["0 - Test Task 1", "1 - Test Task 2"] => true
+  private func assertVisibleTasksMatch(_ expectedTaskLabels: [String]) {
+    let visibleTaskLabels = app.collectionViews.cells.allElementsBoundByIndex
+    .compactMap { cell in
+        cell.staticTexts["taskName"].label
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    guard expectedTaskLabels.count == visibleTaskLabels.count else {
+      XCTFail("""
+        Array counts don't match: expected \(expectedTaskLabels.count), \
+        got \(visibleTaskLabels.count)
+      """)
+      return
     }
-
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    
+    for (index, expectedTask) in expectedTaskLabels.enumerated() {
+      XCTAssert(
+        visibleTaskLabels[index].contains(expectedTask),
+        """
+        Task at index \(index) should contain '\(expectedTask)' \
+        but got '\(visibleTaskLabels[index])'
+        """
+      )
     }
+  }
+  
+  private func openTestList(named testListName: String) {
+    let sidebarCollectionView = app.collectionViews["Sidebar"]
+    let testListCell = sidebarCollectionView.cells
+      .containing(.staticText, identifier: testListName)
+      .allElementsBoundByIndex.last!
+    testListCell.tap()
+  }
+  
+  private func deleteTestList(named testListName: String) {
+    let sidebarCollectionView = app.collectionViews["Sidebar"]
+    let testListCell = sidebarCollectionView.cells
+      .containing(.staticText, identifier: testListName)
+      .allElementsBoundByIndex.last!
+    
+    testListCell.swipeLeft()
+    sidebarCollectionView.buttons["Delete"].tap()
+  }
 
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
+  func testManuallyCreatingListAndTasks() throws {
+    let testListName = "Test List"
+    
+    let navBar = app.navigationBars.firstMatch
+    navBar.buttons["Add List"].tap()
+    app.textFields["Name"].typeText(testListName)
+    app.collectionViews.buttons["Add List"].tap()
+    
+    openTestList(named: testListName)
+    
+    let collectionViewsQuery = app.collectionViews
+    
+    // Add multiple tasks
+    for i in 1...5 {
+      navBar.buttons["Add Task"].tap()
+      let nameTextField = collectionViewsQuery.textFields["Name"]
+      nameTextField.typeText("Task \(i)")
+      app.collectionViews.buttons["Add Task"].tap()
     }
+    
+    // Each new task currently gets added to the top of the list
+    let expectedVisibleTasks
+      = ["Task 5", "Task 4", "Task 3", "Task 2", "Task 1"]
+    assertVisibleTasksMatch(expectedVisibleTasks)
+
+    navBar.buttons["Back"].tap()
+    deleteTestList(named: testListName)
+  }
+  
+  /// Given some tasks are completed and hidden, ensures that:
+  /// - Task deletion results in the correct task being deleted
+  /// - Task reordering results in the correct task order
+  func testDeletingAndReorderingCorrectTask() throws {
+    let testListName = "Test List 1"
+    let navBar = app.navigationBars.firstMatch
+    
+    // Open the test list and validate the initial order
+    openTestList(named: testListName)
+    
+    let collectionViewsQuery = app.collectionViews
+    var expectedVisibleTasks
+      = ["Task 1", "Task 2", "Task 3", "Task 4", "Task 5"]
+    assertVisibleTasksMatch(expectedVisibleTasks)
+    
+    // Check off a task and validate remaining visible task order
+    let taskToComplete = collectionViewsQuery.cells.firstMatch
+    taskToComplete.tap()
+    taskToComplete.waitForNonExistence(timeout: 2)
+    
+    expectedVisibleTasks.removeFirst() // 2, 3, 4, 5
+    assertVisibleTasksMatch(expectedVisibleTasks)
+
+    // Delete a task and validate remaining visible task order
+    let taskToDelete = collectionViewsQuery.cells.firstMatch
+    taskToDelete.swipeLeft()
+    app.buttons["Delete"].tap()
+    
+    expectedVisibleTasks.removeFirst() // 3, 4, 5
+    assertVisibleTasksMatch(expectedVisibleTasks)
+    
+    // Move the first visible task to the position of the last visible task
+    // and validate the remaining visible task order
+    let firstCell = collectionViewsQuery.cells.firstMatch
+    let lastCell = collectionViewsQuery.cells.element(
+      boundBy: expectedVisibleTasks.count - 1
+    )
+    
+    let start = firstCell
+      .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+    let finish = lastCell
+      .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+    start.press(
+      forDuration: 0.5,
+      thenDragTo: finish,
+      withVelocity: .slow,
+      thenHoldForDuration: 0.5
+    )
+    
+    let movedTask = expectedVisibleTasks.removeFirst()
+    expectedVisibleTasks.append(movedTask) // 4, 5, 3
+    assertVisibleTasksMatch(expectedVisibleTasks)
+    
+    navBar.buttons["Back"].tap()
+    deleteTestList(named: testListName)
+  }
+  
+  func testLaunchPerformance() throws {
+    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // This measures how long it takes to launch your application.
+      measure(metrics: [XCTApplicationLaunchMetric()]) {
+        XCUIApplication().launch()
+      }
+    }
+  }
 }


### PR DESCRIPTION
Resolves #14

## Feature
- Added eye icon to navbar to toggle visibility of completed tasks.
  - Hide is default upon entering any list, and user toggling does not persist
- When completed task visibility is off,
  - A 3s animation plays when a task is checked, and then the task disappears
  - If another task is checked in the meantime, the animation restarts and all
    tasks disappear after no further tasks have been checked in 3s
    - The intention is to avoid an immediate layout shift when the user wishes
      check several tasks in quick succession

## UI Tests
- During development a bug was introduced:
  - Given some task(s) are hidden
    - When a task is moved to a different place in the order, or
    - When a task is deleted
      - The wrong task may be reordered or deleted
- UI Testing was introducted, including a test to guard against the above issue.
- Github Actions was configured to run all tests on PR/Push to main

### UI Test fail (bug repro) - wrong task deleted

https://github.com/user-attachments/assets/67e9d030-63b3-4dee-8d99-4fa7832aa6de



### UI Test fail (bug repro) - tasks reordered incorrectly

https://github.com/user-attachments/assets/909e8158-ce8d-4c79-ae71-0cb084825acd



### UI Test pass (bugs fixed)


https://github.com/user-attachments/assets/819561fd-319a-4c90-b5e8-e2febceff7ad





## Misc
- Added some `Color` helpers